### PR TITLE
拡張機能のアップデートで保存しているデータを引き継ぐ

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "SchedulePicker",
-    "version": "3.0.2",
+    "version": "3.0.4",
     "manifest_version": 2,
     "description": "ガルーンの今日のスケジュール情報を取得して、kintoneスレッドなどに挿入するChrome拡張。ハッカソン2019",
     "icons": {

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -293,13 +293,15 @@ chrome.runtime.onMessage.addListener((message, sender) => {
     }
 });
 
-chrome.runtime.onInstalled.addListener(() => {
-    chrome.storage.sync.set({
-        dateType: DateType.TODAY,
-        isIncludePrivateEvent: true,
-        isIncludeAllDayEvent: true,
-        templateText: `今日の予定を取得できるよ<br>{%TODAY%}<div><br><div>翌営業日の予定を取得できるよ<br>{%NEXT_BUSINESS_DAY%}</div><div><br></div><div>前営業日の予定を取得できるよ<br>{%PREVIOUS_BUSINESS_DAY%}</div></div>`,
-    });
+chrome.runtime.onInstalled.addListener(details => {
+    if (details.reason === 'install') {
+        chrome.storage.sync.set({
+            dateType: DateType.TODAY,
+            isIncludePrivateEvent: true,
+            isIncludeAllDayEvent: true,
+            templateText: `今日の予定を取得できるよ<br>{%TODAY%}<div><br><div>翌営業日の予定を取得できるよ<br>{%NEXT_BUSINESS_DAY%}</div><div><br></div><div>前営業日の予定を取得できるよ<br>{%PREVIOUS_BUSINESS_DAY%}</div></div>`,
+        });
+    }
 });
 
 setupContextMenus();


### PR DESCRIPTION
@mkeeda さんのプルリクを元に作成
https://github.com/kuroppe1819/SchedulePicker2/pull/1

アップデート時も chrome.runtime.onInstalled.addListener に登録したイベントハンドラが実行されるため、コールバック関数の中で、初回アップデート時のみストレージに初期値をセットする分岐を追加した。
https://stackoverflow.com/questions/2399389/detect-chrome-extension-first-run-update